### PR TITLE
Implemented requested coast mode for movement after teleop

### DIFF
--- a/2025-Janice/src/main/java/frc/robot/RobotContainer.java
+++ b/2025-Janice/src/main/java/frc/robot/RobotContainer.java
@@ -328,6 +328,12 @@ public class RobotContainer {
                 () -> -driveController.getLeftX(),
                 () -> -driveController.getRightX(),
                 () -> Constants.driveRobotRelative));
+        // drive to closest reef
+    //driveController.y().whileTrue(new DriveToReef(drive, ReefDirection.CENTER));
+    driveController.x().whileTrue(new DriveToReef(drive, ReefDirection.LEFT));
+    driveController.b().whileTrue(new DriveToReef(drive, ReefDirection.RIGHT));
+    driveController.a().whileTrue(new DriveToHumanPlayer(drive));
+    driveController.y().onTrue(new InstantCommand( () -> drive.requestCoast() ));
 
     // driveController
     //     .a()
@@ -381,14 +387,6 @@ public class RobotContainer {
     operatorController.leftTrigger(0.8).whileTrue(new RepeatCommand( new InstantCommand( () -> outtake.outtake(), outtake )));
     //operatorController.leftTrigger(0.8).whileFalse(new InstantCommand(() -> outtake.processCoral(), outtake ));
     deAlgifier.setDefaultCommand(new InstantCommand(() -> deAlgifier.deAlgify(operatorController.getRightY()), deAlgifier));
-
-
-
-    // drive to closest reef
-    //driveController.y().whileTrue(new DriveToReef(drive, ReefDirection.CENTER));
-    driveController.x().whileTrue(new DriveToReef(drive, ReefDirection.LEFT));
-    driveController.b().whileTrue(new DriveToReef(drive, ReefDirection.RIGHT));
-    driveController.a().whileTrue(new DriveToHumanPlayer(drive));
 
     operatorController.povUp().and(operatorController.start().and(operatorController.rightStick())).whileTrue(new InstantCommand(() -> climber.setClimbState(true)));
     

--- a/2025-Janice/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/2025-Janice/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -77,6 +77,8 @@ public class Drive extends SubsystemBase {
   private Pose2d visionPose = new Pose2d();  
   private Rotation2d lastGyroRotation = new Rotation2d();
   private Pose2d filteredPhotonPose2d = new Pose2d();
+  private boolean coastRequest = false;
+  private boolean isBrakeModeDrive = true;
 
   //private PhotonVision photonCam;
   private int initVisionCount;
@@ -238,6 +240,21 @@ public class Drive extends SubsystemBase {
             gyroInputs.connected
                 ? gyroInputs.yawVelocityRadPerSec
                 : chassisSpeeds.omegaRadiansPerSecond);
+
+    // if a coast is requested during tele-op, set the motors to coast when the robot gets disabled
+    if( DriverStation.isDisabled() && coastRequest ) {
+      for( Module module : modules )
+        module.setDriveBrakeMode(false);
+      coastRequest = false;
+      isBrakeModeDrive = false;
+    }
+
+    //Once the robot is reinabled after being on coast in disable, reenable brake mode
+    if( DriverStation.isEnabled() && !isBrakeModeDrive ) {
+      for( Module module : modules )
+        module.setDriveBrakeMode(true);
+      isBrakeModeDrive = true;
+    }
   }
 
   /**
@@ -346,6 +363,10 @@ public class Drive extends SubsystemBase {
 
   public Pose2d getfilteredPhotonPose2d() {
     return filteredPhotonPose2d;
+  }
+
+  public void requestCoast() {
+    coastRequest = true;
   }
 
   /** Resets the current odometry odometryPose. */

--- a/2025-Janice/src/main/java/frc/robot/subsystems/drive/Module.java
+++ b/2025-Janice/src/main/java/frc/robot/subsystems/drive/Module.java
@@ -170,6 +170,10 @@ public class Module {
     io.setTurnBrakeMode(enabled);
   }
 
+  public void setDriveBrakeMode( boolean enabled ) {
+    io.setDriveBrakeMode(enabled);
+  }
+
   /** Returns the current turn angle of the module. */
   public Rotation2d getAngle() {
     if (turnRelativeOffset == null) {


### PR DESCRIPTION
the intended behavior is that the drive motors will be set to coast during disabling if it is requested as such during teleop. This is so our robot can continue to move with its given momentum after the clock hits zero, so the driver can give the robot momentum to park within the last 2 seconds. The robot will continue in that direction even after the FMS disables all robots.