### PR TITLE
New DeAlgifier

### DIFF
--- a/2025-Janice/src/main/java/frc/robot/Constants.java
+++ b/2025-Janice/src/main/java/frc/robot/Constants.java
@@ -84,7 +84,7 @@ public final class Constants {
     //TODO find real value
     public static final int kOuttakeMotor = 51;
 
-    public static final int kDeAlgifierLaterator = 39;
+    public static final int kDeAlgifierLaterator = 37;
     public static final int kDeAlgifierGrabber = 38;
     //TODO someone check this please.
   }
@@ -198,11 +198,11 @@ public final class Constants {
   }
 
 public static final class DeAlgifierConstants {
-  public static final int kFrontLimitSwitchChannel = 0; //TODO: find these
-  public static final int kBackLimitSwitchChannel = 0;
+  public static final int kFrontLimitSwitchChannel = 2; //TODO: find these
+  public static final int kBackLimitSwitchChannel = 3;
 
   public static final double kDeAlgifierGrabberCurrentLimit = 60; //amps
-  public static final double kDeAlgifierLateratorCurrentLimit = 20; // low to make sure does not overrdrive into hard stop
+  public static final double kDeAlgifierLateratorCurrentLimit = 10; // low to make sure does not overrdrive into hard stop
 
   public static final double kLateratorGearRatio = 5;
   public static final double kGrabberGearRatio = 3.86;

--- a/2025-Janice/src/main/java/frc/robot/Constants.java
+++ b/2025-Janice/src/main/java/frc/robot/Constants.java
@@ -202,7 +202,7 @@ public static final class DeAlgifierConstants {
   public static final int kBackLimitSwitchChannel = 3;
 
   public static final double kDeAlgifierGrabberCurrentLimit = 60; //amps
-  public static final double kDeAlgifierLateratorCurrentLimit = 10; // low to make sure does not overrdrive into hard stop
+  public static final double kDeAlgifierLateratorCurrentLimit = 30; // low to make sure does not overrdrive into hard stop
 
   public static final double kLateratorGearRatio = 5;
   public static final double kGrabberGearRatio = 3.86;

--- a/2025-Janice/src/main/java/frc/robot/Constants.java
+++ b/2025-Janice/src/main/java/frc/robot/Constants.java
@@ -202,6 +202,8 @@ public static final class DeAlgifierConstants {
   public static final int kBackLimitSwitchChannel = 0;
 
   public static final double kDeAlgifierGrabberCurrentLimit = 60; //amps
+  public static final double kDeAlgifierLateratorCurrentLimit = 20; // low to make sure does not overrdrive into hard stop
+
   public static final double kLateratorGearRatio = 5;
   public static final double kGrabberGearRatio = 3.86;
 
@@ -210,10 +212,9 @@ public static final class DeAlgifierConstants {
   public static final double kGrabberP = 1.0;
   public static final double kGrabberD = 0.0;
 
-  public static final double kLateratorVelocityLimitRadPerSec = 5;
-
-  public static final double kLateratorInPositionRad = 5.0;
+  public static final double kLateratorInPositionRad = 5.0; //only used in SIM
   public static final double kLateratorOutPositionRad = -5.0; //TODO: UPDATE THESE
+
   public static final double kLateratorVelocityGoalRadPerSec = 5;
   public static final double kLateratorPVelocity = 2.0;
   public static final double kLateratorDVelocity = 0.0;

--- a/2025-Janice/src/main/java/frc/robot/Constants.java
+++ b/2025-Janice/src/main/java/frc/robot/Constants.java
@@ -84,8 +84,8 @@ public final class Constants {
     //TODO find real value
     public static final int kOuttakeMotor = 51;
 
-    public static final int kDeAlgifierKicker = 39;
-    public static final int kDeAlgifierArm = 38;
+    public static final int kDeAlgifierLaterator = 39;
+    public static final int kDeAlgifierGrabber = 38;
     //TODO someone check this please.
   }
 
@@ -198,17 +198,25 @@ public final class Constants {
   }
 
 public static final class DeAlgifierConstants {
-  public static final double kDeAlgifierCurrentLimit = 30;
-  public static final double kArmGearRatio = 28;
-  public static final double kKickerGearRatio = 1; //TODO find gear ratio
+  public static final int kFrontLimitSwitchChannel = 0; //TODO: find these
+  public static final int kBackLimitSwitchChannel = 0;
 
-  public static final double kArmAlgaeSetpointRad = 2.0;
-  public static final double kKickerSetpointRPM = 6000;
+  public static final double kDeAlgifierGrabberCurrentLimit = 60; //amps
+  public static final double kLateratorGearRatio = 5;
+  public static final double kGrabberGearRatio = 3.86;
 
-  public static final double ARM_P = 3.0;
-  public static final double ARM_D = 0.0;
-  public static final double KICKER_P = 0.0012;
-  public static final double KICKER_D = 0.0;
+  public static final double kGrabberIntakeSetpointRPM = 0.0;
+  public static final double kGrabberEjectSetpointRPM = 0.0;
+  public static final double kGrabberP = 1.0;
+  public static final double kGrabberD = 0.0;
+
+  public static final double kLateratorVelocityLimitRadPerSec = 5;
+
+  public static final double kLateratorInPositionRad = 5.0;
+  public static final double kLateratorOutPositionRad = -5.0; //TODO: UPDATE THESE
+  public static final double kLateratorVelocityGoalRadPerSec = 5;
+  public static final double kLateratorPVelocity = 2.0;
+  public static final double kLateratorDVelocity = 0.0;
 }
 
 

--- a/2025-Janice/src/main/java/frc/robot/RobotContainer.java
+++ b/2025-Janice/src/main/java/frc/robot/RobotContainer.java
@@ -387,10 +387,10 @@ public class RobotContainer {
     outtake.setDefaultCommand(new InstantCommand(() -> outtake.stop(), outtake ) );
     operatorController.leftTrigger(0.8).whileTrue(new RepeatCommand( new InstantCommand( () -> outtake.outtake(), outtake )));
 
-    
+
     //axis 4 is Right X
     operatorController.axisGreaterThan(4, 0.8).onTrue( new RepeatCommand(new InstantCommand( () -> deAlgifier.lateratorOut() )));
-    operatorController.axisLessThan(4, 0.8).onTrue( new RepeatCommand(new InstantCommand( () -> deAlgifier.lateratorIn() )));
+    operatorController.axisLessThan(4, -0.8).onTrue( new RepeatCommand(new InstantCommand( () -> deAlgifier.lateratorIn() )));
 
     operatorController.rightTrigger(0.8).whileTrue(new RepeatCommand(new InstantCommand( () -> deAlgifier.intake() )));
     operatorController.rightBumper().whileTrue(new RepeatCommand(new InstantCommand( () -> deAlgifier.outtake() )));

--- a/2025-Janice/src/main/java/frc/robot/RobotContainer.java
+++ b/2025-Janice/src/main/java/frc/robot/RobotContainer.java
@@ -3,22 +3,15 @@ package frc.robot;
 import static edu.wpi.first.units.Units.Seconds;
 
 import org.littletonrobotics.junction.networktables.LoggedDashboardChooser;
-import org.photonvision.targeting.PhotonTrackedTarget;
-
 import com.pathplanner.lib.auto.AutoBuilder;
 import com.pathplanner.lib.auto.NamedCommands;
-import com.pathplanner.lib.path.PathPlannerPath;
-
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.util.Units;
-import edu.wpi.first.networktables.GenericEntry;
 import edu.wpi.first.units.measure.Time;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.XboxController;
-import edu.wpi.first.wpilibj.PS4Controller.Axis;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -27,32 +20,24 @@ import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.RepeatCommand;
 import edu.wpi.first.wpilibj2.command.WaitCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
-import frc.robot.Constants.RobotType;
 import frc.robot.commands.AutoCommands;
 import frc.robot.commands.DriveCommands;
 import frc.robot.commands.DriveToHumanPlayer;
-import frc.robot.commands.DriveToPose;
 import frc.robot.commands.DriveToReef;
 import frc.robot.commands.DriveToReef.ReefDirection;
 import frc.robot.subsystems.DeAlgifier.DeAlgifier;
-import frc.robot.subsystems.DeAlgifier.DeAlgifierIO;
 import frc.robot.subsystems.DeAlgifier.DeAlgifierIOReal;
 import frc.robot.subsystems.DeAlgifier.DeAlgifierIOSim;
-import frc.robot.subsystems.Intake.Intake;
-import frc.robot.subsystems.Intake.IntakeIOReal;
-import frc.robot.subsystems.Intake.IntakeIOSim;
 import frc.robot.subsystems.Outtake.Outtake;
 import frc.robot.subsystems.Outtake.OuttakeIO;
 import frc.robot.subsystems.Outtake.OuttakeIOSim;
 import frc.robot.subsystems.Outtake.OuttakeIOReal;
 import frc.robot.subsystems.climber.Climber;
 import frc.robot.subsystems.climber.ClimberIO;
-import frc.robot.subsystems.climber.ClimberIOReal;
 import frc.robot.subsystems.climber.ClimberIOSim;
 import frc.robot.subsystems.drive.Drive;
 import frc.robot.subsystems.drive.GyroIO;
 import frc.robot.subsystems.drive.GyroIONAVX;
-import frc.robot.subsystems.drive.GyroIORedux;
 import frc.robot.subsystems.drive.ModuleIO;
 import frc.robot.subsystems.drive.ModuleIOMaxSwerve;
 import frc.robot.subsystems.drive.ModuleIOSim;
@@ -68,8 +53,6 @@ import frc.robot.util.LoggedTunableNumber;
 import frc.robot.subsystems.vision.VisionIO;
 import frc.robot.subsystems.vision.VisionIOPhotonVisionSim;
 import static frc.robot.subsystems.vision.VisionConstants.*;
-
-import java.lang.annotation.Repeatable;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a
@@ -224,7 +207,7 @@ public class RobotContainer {
         elevator = new Elevator(new ElevatorIO() {});
         outtake = new Outtake(new OuttakeIO() {});
         climber = new Climber(new ClimberIO() {});
-        deAlgifier = new DeAlgifier(new DeAlgifierIO() {});
+        deAlgifier = new DeAlgifier(new DeAlgifierIOSim() {});
         // (Use same number of dummy implementations as the real robot)
         vision = new Vision(drive::addVisionMeasurement, new VisionIO() {}, new VisionIO() {});
         break;

--- a/2025-Janice/src/main/java/frc/robot/RobotContainer.java
+++ b/2025-Janice/src/main/java/frc/robot/RobotContainer.java
@@ -18,6 +18,7 @@ import edu.wpi.first.units.measure.Time;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.XboxController;
+import edu.wpi.first.wpilibj.PS4Controller.Axis;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -385,11 +386,19 @@ public class RobotContainer {
 
     outtake.setDefaultCommand(new InstantCommand(() -> outtake.stop(), outtake ) );
     operatorController.leftTrigger(0.8).whileTrue(new RepeatCommand( new InstantCommand( () -> outtake.outtake(), outtake )));
-    //operatorController.leftTrigger(0.8).whileFalse(new InstantCommand(() -> outtake.processCoral(), outtake ));
-    deAlgifier.setDefaultCommand(new InstantCommand(() -> deAlgifier.deAlgify(operatorController.getRightY()), deAlgifier));
 
-    operatorController.povUp().and(operatorController.start().and(operatorController.rightStick())).whileTrue(new InstantCommand(() -> climber.setClimbState(true)));
     
+    //axis 4 is Right X
+    operatorController.axisGreaterThan(4, 0.8).onTrue( new RepeatCommand(new InstantCommand( () -> deAlgifier.lateratorOut() )));
+    operatorController.axisLessThan(4, 0.8).onTrue( new RepeatCommand(new InstantCommand( () -> deAlgifier.lateratorIn() )));
+
+    operatorController.rightTrigger(0.8).whileTrue(new RepeatCommand(new InstantCommand( () -> deAlgifier.intake() )));
+    operatorController.rightBumper().whileTrue(new RepeatCommand(new InstantCommand( () -> deAlgifier.outtake() )));
+    operatorController.rightTrigger(0.8)
+      .and(operatorController.rightBumper())
+      .whileFalse(new InstantCommand( () -> deAlgifier.holdAlgae()));
+
+
   }
 
   // /**

--- a/2025-Janice/src/main/java/frc/robot/RobotContainer.java
+++ b/2025-Janice/src/main/java/frc/robot/RobotContainer.java
@@ -371,9 +371,10 @@ public class RobotContainer {
     operatorController.leftTrigger(0.8).whileTrue(new RepeatCommand( new InstantCommand( () -> outtake.outtake(), outtake )));
 
 
-    //axis 4 is Right X
-    operatorController.axisGreaterThan(4, 0.8).onTrue( new RepeatCommand(new InstantCommand( () -> deAlgifier.lateratorOut() )));
-    operatorController.axisLessThan(4, -0.8).onTrue( new RepeatCommand(new InstantCommand( () -> deAlgifier.lateratorIn() )));
+    // //axis 4 is Right X
+    // operatorController.axisGreaterThan(4, 0.8).onTrue( new RepeatCommand(new InstantCommand( () -> deAlgifier.lateratorOut() )));
+    // operatorController.axisLessThan(4, -0.8).onTrue( new RepeatCommand(new InstantCommand( () -> deAlgifier.lateratorIn() )));
+    deAlgifier.setDefaultCommand(new InstantCommand(() -> deAlgifier.lateratorManual(operatorController.getRightY()), deAlgifier));
 
     operatorController.rightTrigger(0.8).whileTrue(new RepeatCommand(new InstantCommand( () -> deAlgifier.intake() )));
     operatorController.rightBumper().whileTrue(new RepeatCommand(new InstantCommand( () -> deAlgifier.outtake() )));

--- a/2025-Janice/src/main/java/frc/robot/subsystems/DeAlgifier/DeAlgifier.java
+++ b/2025-Janice/src/main/java/frc/robot/subsystems/DeAlgifier/DeAlgifier.java
@@ -18,10 +18,14 @@ public class DeAlgifier extends SubsystemBase{
     private LateratorMode lateratorMode;
     private GrabberMode grabberMode;
 
+    private double lateralManual = 0.0;
+
+    boolean manual = true;
+
     enum LateratorMode {
         IN,
         OUT,
-        IDLE
+        IDLE,
     }
 
     enum GrabberMode {
@@ -57,8 +61,11 @@ public class DeAlgifier extends SubsystemBase{
 
              return;
         } 
-
-        switch( lateratorMode ) {
+        if(manual){
+            io.setLateratorVoltage(lateralManual);
+        }else{
+        
+            switch( lateratorMode ) {
             case IN -> {
                 if( !inputs.backLimitSwitch)
                     io.setLateratorVoltage(lateratorPidController.calculate(
@@ -87,6 +94,7 @@ public class DeAlgifier extends SubsystemBase{
             case HOLD, IDLE -> io.setGrabberBrake(true);
             default -> io.setGrabberBrake(true);
         }
+        }
     }
     
 
@@ -95,6 +103,10 @@ public class DeAlgifier extends SubsystemBase{
      */
     public void lateratorOut() {
         lateratorMode = LateratorMode.OUT;
+    }
+
+    public void lateratorManual(double input){
+        lateralManual = input*2.0;
     }
 
     /**

--- a/2025-Janice/src/main/java/frc/robot/subsystems/DeAlgifier/DeAlgifier.java
+++ b/2025-Janice/src/main/java/frc/robot/subsystems/DeAlgifier/DeAlgifier.java
@@ -12,11 +12,15 @@ public class DeAlgifier extends SubsystemBase{
 
     private final PIDController lateratorPidController;
     private final PIDController grabberPidController;
+
     
     public DeAlgifier(DeAlgifierIO io){
         this.io = io;
         lateratorPidController = new PIDController(DeAlgifierConstants.kLateratorPVelocity, 0, DeAlgifierConstants.kLateratorDVelocity);
         grabberPidController = new PIDController(DeAlgifierConstants.kGrabberP, 0, DeAlgifierConstants.kGrabberD);
+
+        lateratorPidController.reset();
+        grabberPidController.reset();
     }
     
     public void periodic(){

--- a/2025-Janice/src/main/java/frc/robot/subsystems/DeAlgifier/DeAlgifier.java
+++ b/2025-Janice/src/main/java/frc/robot/subsystems/DeAlgifier/DeAlgifier.java
@@ -6,8 +6,6 @@ import frc.robot.Constants.DeAlgifierConstants;
 
 import org.littletonrobotics.junction.Logger;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-
 public class DeAlgifier extends SubsystemBase{
     private DeAlgifierIO io;
     private final DeAlgifierIOInputsAutoLogged inputs = new DeAlgifierIOInputsAutoLogged();
@@ -106,7 +104,7 @@ public class DeAlgifier extends SubsystemBase{
     }
 
     public void lateratorManual(double input){
-        lateralManual = input*2.0;
+        lateralManual = input*4.0;
     }
 
     /**

--- a/2025-Janice/src/main/java/frc/robot/subsystems/DeAlgifier/DeAlgifierIO.java
+++ b/2025-Janice/src/main/java/frc/robot/subsystems/DeAlgifier/DeAlgifierIO.java
@@ -5,21 +5,27 @@ public interface DeAlgifierIO {
 
     @AutoLog
     public static class DeAlgifierIOInputs {
-        public double armMotorVoltage = 0.0;
-        public double armSupplyVoltage = 0.0;
-        public double armCurrentAmps = 0.0;
-        public double armPositionRad = 0.0;
+        public double lateratorMotorVoltage = 0.0;
+        public double lateratorSupplyVoltage = 0.0;
+        public double lateratorCurrentAmps = 0.0;
+        public double lateratorPositionRad = 0.0;
+        public double lateratorVelocityRadPerSec = 0.0;
 
-        public double kickerMotorVoltage = 0.0;
-        public double kickerSupplyVoltage = 0.0;
-        public double kickerCurrentAmps = 0.0;
-        public double kickerVelocityRPM = 0.0;
+        public double grabberMotorVoltage = 0.0;
+        public double grabberSupplyVoltage = 0.0;
+        public double grabberCurrentAmps = 0.0;
+        public double grabberVelocityRPM = 0.0;
+
+        public boolean frontLimitSwitch = false;
+        public boolean backLimitSwitch = false;
     }
         /** Updates the set of loggable inputs. */
         public default void updateInputs(DeAlgifierIOInputs inputs) {}
         
         /** Set voltage command */
-        public default void setArmVoltage(double voltage) {}
+        public default void setLateratorVoltage(double voltage) {}
 
-        public default void setKickerVoltage( double voltage ) {}
+        public default void setGrabberVoltage( double voltage ) {}
+
+        public default void setGrabberBrake(boolean enable) {} 
 }

--- a/2025-Janice/src/main/java/frc/robot/subsystems/DeAlgifier/DeAlgifierIO.java
+++ b/2025-Janice/src/main/java/frc/robot/subsystems/DeAlgifier/DeAlgifierIO.java
@@ -20,7 +20,7 @@ public interface DeAlgifierIO {
         public boolean backLimitSwitch = false;
     }
         /** Updates the set of loggable inputs. */
-        public default void updateInputs(DeAlgifierIOInputs inputs) {}
+        public void updateInputs(DeAlgifierIOInputs inputs);
         
         /** Set voltage command */
         public default void setLateratorVoltage(double voltage) {}

--- a/2025-Janice/src/main/java/frc/robot/subsystems/DeAlgifier/DeAlgifierIOReal.java
+++ b/2025-Janice/src/main/java/frc/robot/subsystems/DeAlgifier/DeAlgifierIOReal.java
@@ -26,7 +26,7 @@ public class DeAlgifierIOReal implements DeAlgifierIO {
     public DeAlgifierIOReal() {
         laterator = new TalonFX(CAN.kDeAlgifierLaterator, "Elevator");
         TalonFXConfiguration lateratorConfig = new TalonFXConfiguration();
-        lateratorConfig.CurrentLimits.StatorCurrentLimit = 30;
+        lateratorConfig.CurrentLimits.StatorCurrentLimit = 20;
         lateratorConfig.CurrentLimits.StatorCurrentLimitEnable = true;
         lateratorConfig.MotorOutput.NeutralMode = NeutralModeValue.Brake;
         lateratorConfig.Feedback.SensorToMechanismRatio = DeAlgifierConstants.kLateratorGearRatio;

--- a/2025-Janice/src/main/java/frc/robot/subsystems/DeAlgifier/DeAlgifierIOReal.java
+++ b/2025-Janice/src/main/java/frc/robot/subsystems/DeAlgifier/DeAlgifierIOReal.java
@@ -43,7 +43,6 @@ public class DeAlgifierIOReal implements DeAlgifierIO {
         grabber.getConfigurator().apply(grabberConfig);
 
         staticBrake = new StaticBrake();
-        staticBrake.UpdateFreqHz = 30;
 
         voltageControl = new VoltageOut(0.0);
         grabber.setControl(voltageControl);
@@ -79,9 +78,6 @@ public class DeAlgifierIOReal implements DeAlgifierIO {
     }
 
     public void setGrabberBrake( boolean enable ) {
-        if( enable )
-            grabber.setControl(staticBrake);
-        else
-            grabber.setControl(voltageControl);
+        grabber.setControl(enable ? staticBrake : voltageControl);
     }
 }

--- a/2025-Janice/src/main/java/frc/robot/subsystems/DeAlgifier/DeAlgifierIOSim.java
+++ b/2025-Janice/src/main/java/frc/robot/subsystems/DeAlgifier/DeAlgifierIOSim.java
@@ -45,4 +45,10 @@ public class DeAlgifierIOSim implements DeAlgifierIO {
     public void setGrabberVoltage( double voltage ) {
         grabberMotor.setInputVoltage(voltage);
     }
+
+    @Override
+    public void setGrabberBrake( boolean enable ) {
+        if( enable )
+            grabberMotor.setInputVoltage(0);
+    }
 }

--- a/2025-Janice/src/main/java/frc/robot/subsystems/DeAlgifier/DeAlgifierIOSim.java
+++ b/2025-Janice/src/main/java/frc/robot/subsystems/DeAlgifier/DeAlgifierIOSim.java
@@ -7,38 +7,42 @@ import frc.robot.Constants.DeAlgifierConstants;
 
 public class DeAlgifierIOSim implements DeAlgifierIO {
     
-    private static final DCMotor arm = DCMotor.getFalcon500(1);
-    private static final DCMotor kicker = DCMotor.getNeo550(1);
+    private static final DCMotor laterator = DCMotor.getKrakenX60(1);
+    private static final DCMotor grabber = DCMotor.getFalcon500(1);
 
-    private final DCMotorSim armMotor =
+    private final DCMotorSim lateratorMotor =
       new DCMotorSim(
-          LinearSystemId.createDCMotorSystem(arm, 0.025, 1.0),
-          arm);
+          LinearSystemId.createDCMotorSystem(laterator, 0.025, DeAlgifierConstants.kLateratorGearRatio),
+          laterator);
     
-    private final DCMotorSim kickerMotor =
+    private final DCMotorSim grabberMotor =
       new DCMotorSim(
-          LinearSystemId.createDCMotorSystem(kicker, 0.025, DeAlgifierConstants.kKickerGearRatio),
-          kicker);
+          LinearSystemId.createDCMotorSystem(grabber, 0.025, DeAlgifierConstants.kGrabberGearRatio),
+          grabber);
 
     public void updateInputs(DeAlgifierIOInputs inputs){ //TODO: fix these update inputs
-        inputs.armMotorVoltage = armMotor.getInputVoltage();
-        inputs.armSupplyVoltage = armMotor.getInputVoltage();
-        inputs.armCurrentAmps = armMotor.getCurrentDrawAmps();
-        inputs.armPositionRad = armMotor.getAngularPositionRad();
+        inputs.lateratorMotorVoltage = lateratorMotor.getInputVoltage();
+        inputs.lateratorCurrentAmps = lateratorMotor.getCurrentDrawAmps();
+        inputs.lateratorSupplyVoltage = lateratorMotor.getInputVoltage();
+        inputs.lateratorPositionRad = lateratorMotor.getAngularPositionRad();
+        inputs.lateratorVelocityRadPerSec = lateratorMotor.getAngularVelocityRadPerSec();
 
-        inputs.kickerMotorVoltage = kickerMotor.getInputVoltage();
-        inputs.kickerSupplyVoltage = kickerMotor.getInputVoltage();
-        inputs.kickerCurrentAmps = kickerMotor.getCurrentDrawAmps();
-        inputs.kickerVelocityRPM = kickerMotor.getAngularVelocityRPM();
+        inputs.grabberMotorVoltage = grabberMotor.getInputVoltage();
+        inputs.grabberSupplyVoltage = grabberMotor.getInputVoltage();
+        inputs.grabberCurrentAmps = grabberMotor.getCurrentDrawAmps();
+        inputs.grabberVelocityRPM = grabberMotor.getAngularVelocityRPM();
+
+        inputs.frontLimitSwitch = inputs.lateratorPositionRad > DeAlgifierConstants.kLateratorOutPositionRad;
+        inputs.backLimitSwitch = inputs.lateratorPositionRad < DeAlgifierConstants.kLateratorInPositionRad;
     }
 
     @Override
-    public void setArmVoltage( double voltage ) {
-        armMotor.setInputVoltage(voltage);
+    public void setLateratorVoltage(double voltage){
+        lateratorMotor.setInputVoltage(voltage);
     }
 
     @Override
-    public void setKickerVoltage( double voltage ) {
-        kickerMotor.setInputVoltage(voltage);
+    public void setGrabberVoltage( double voltage ) {
+        grabberMotor.setInputVoltage(voltage);
     }
 }


### PR DESCRIPTION
### Attempt at new dealgifier code.

By Nate's instructions there will be a forward and backward limit switch because I don't want to trust the compliant wheel rubbing against the metal for position data. So we're going to run the motor in or out at some velocity until it hits the limit switch. 

Another thing of importance is holding the algae once its in our robot. I saw a lot of teams try to keep the intake setpoint once an algae was in their control, but that ended up stalling the motors and causing the algae to drop. Instead, what I wanted to try is a StaticBrake, stronger than the normal idle mode brake, but requring some new control schemes with CTRE's control base. If this does not work (which I sort of suspect), we can go back to intaking the algae farther into our robot. 
I would love for a limit switch to be placed in the back of the grabber to indicate if or not we have an algae, but I don't see that going on soon, so for autos I will add support for .withTimeout() on the intake.

Oh also CAN ID's need to be updated are:
- Laterator: ID **39**
- Grabber: ID **38**

and we need the two new limit switch channels.

Note: StaticBrake shorts motor leads together so any input voltage is translated the other direction, similar to Lenz law. NeutralModeBrake simply applys zero volts to the motor and just revolves around friction. NeutralModeCoast applys zero amps to the motor and thus regards zero torque.